### PR TITLE
remove comma delimiters & matching both letter cases of "Target"

### DIFF
--- a/Cat Nuke Thing.user.js
+++ b/Cat Nuke Thing.user.js
@@ -98,7 +98,7 @@ function update() {
     if ((oldTargetNum != targetNum && onSheet())) {
         oldTargetNum = targetNum;
         console.log("hi")
-        var targetNums = Array.from(document.querySelectorAll('a')).filter(a => a.textContent === "target");
+        var targetNums = Array.from(document.querySelectorAll('a')).filter(a => a.textContent.toLowerCase() === "target");
         targetNums.forEach(function (link) {
             link.href = link.href.replace(/start=\d+/, "start=" + Math.max(Math.floor(Math.random() * (targetNum - 50)),0));
         });
@@ -107,7 +107,7 @@ function update() {
 
     if ((oldTarget != target && onSheet())) {
         oldTarget = target;
-        var targets = Array.from(document.querySelectorAll('a')).filter(a => a.textContent === "target");
+        var targets = Array.from(document.querySelectorAll('a')).filter(a => a.textContent.toLowerCase() === "target");
         targets.forEach(function (link) {
             link.href = link.href.replace(/fid=\d+/, "fid=" + target);
         });

--- a/Cat Nuke Thing.user.js
+++ b/Cat Nuke Thing.user.js
@@ -87,7 +87,7 @@ function moveFocus() {
  * @returns {string} the text of the given indicator
  */
 function numberFromIndicator(indicator) {
-    return document.querySelector(indicator).innerText.split("\n")[0]
+    return document.querySelector(indicator).innerText.split("\n")[0].replaceAll(',', '')
 }
 
 /**


### PR DESCRIPTION
* remove comma delimiters, so 1,000 can be parsed as 1000 correctly, instead of 1
* "NDay Puppet Suite" uses "Target". By matching both letter cases, we can just change `target` and `targetNum` to update the target links instead of rerunning the "NDay Puppet Suite".